### PR TITLE
upgrade to mw1.31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y imagemagick libmagickwand-6.q16-dev --n
 # Intl PHP extension
 RUN apt-get update && apt-get install -y libicu-dev g++ --no-install-recommends && \
     docker-php-ext-install intl && \
-    apt-get install -y --auto-remove libicu52 g++ && \
+    apt-get install -y --auto-remove libicu57 g++ && \
     rm -rf /var/lib/apt/lists/*
 
 # APC PHP extension
@@ -58,7 +58,9 @@ COPY config/supervisor/supervisord.conf /etc/supervisor/conf.d/
 COPY config/supervisor/kill_supervisor.py /usr/bin/
 
 # NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+RUN apt-get update && \
+    apt-get install -y gnupg2 && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y nodejs --no-install-recommends
 
 # Parsoid
@@ -72,7 +74,7 @@ ENV NODE_PATH /usr/lib/parsoid/node_modules:/usr/lib/parsoid/src
 
 # MediaWiki
 ARG MEDIAWIKI_VERSION_MAJOR=1
-ARG MEDIAWIKI_VERSION_MINOR=30
+ARG MEDIAWIKI_VERSION_MINOR=31
 ARG MEDIAWIKI_VERSION_BUGFIX=0
 
 RUN curl -s -o /tmp/keys.txt https://www.mediawiki.org/keys/keys.txt && \

--- a/config/mediawiki/LocalSettings.php
+++ b/config/mediawiki/LocalSettings.php
@@ -163,10 +163,9 @@ if (getenv('MEDIAWIKI_DEFAULT_SKIN') != '') {
 }
 
 # Enabled skins
-wfLoadSkin( 'CologneBlue' );
-wfLoadSkin( 'Modern' );
 wfLoadSkin( 'MonoBook' );
 wfLoadSkin( 'Vector' );
+wfLoadSkin( 'Timeless' );
 
 # Debug
 if (getenv('MEDIAWIKI_DEBUG') == '1') {


### PR DESCRIPTION
Hi @kristophjunge thanks for your work, this bundle saved me some time. According to [Mediawiki's life cycle](https://www.mediawiki.org/wiki/Version_lifecycle), 1.31 is the new LTS, so I went for it. Take care,-NT
